### PR TITLE
Implemented SensorStatusEvent parsing

### DIFF
--- a/LupuServ.sln.DotSettings
+++ b/LupuServ.sln.DotSettings
@@ -4,4 +4,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Innenbereich/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lupu/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lupusec/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=lupuserv/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=lupuserv/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Periodischer/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Sensor_00FCberwachungsfehler/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/README.md
+++ b/README.md
@@ -8,44 +8,69 @@ E-Mail to SMS Gateway service for Lupusec XT1 alarm system
 
 ## Motivation
 
-I happened to know an owner of the very early central alarm system Lupusec XT1 from the German company [Lupus Electronics](https://www.lupus-electronics.de/en/), which has been declared End Of Life several years ago and doesn't receive firmware updates anymore. It appears, that the manufacturer isn't particularly proud of this early revision, as it has become impossible to find resources about it on the company websites (except for the **XT1 Plus** which is *not* the system I'm talking about, but a newer platform).
+I happened to know an owner of the very early central alarm system Lupusec XT1 from the German
+company [Lupus Electronics](https://www.lupus-electronics.de/en/), which has been declared End Of Life several years ago
+and doesn't receive firmware updates anymore. It appears, that the manufacturer isn't particularly proud of this early
+revision, as it has become impossible to find resources about it on the company websites (except for the **XT1 Plus**
+which is *not* the system I'm talking about, but a newer platform).
 
-The system offers a few methods of notifying the outside world about an alarm event, the one in question being able to send a classic SMS message to a maximum of two phone numbers. APIs tend to change or become deprecated, and without firmware updates there isn't much one can do. Which is exactly what happened here; the SMS gateway implementation broke and thanks to this thing not provide any logs or sources, who knows why. This leaves us with a few different channels to grab events from: Contact-ID - which I have no idea what that is and what to do with it - and E-Mail.
+The system offers a few methods of notifying the outside world about an alarm event, the one in question being able to
+send a classic SMS message to a maximum of two phone numbers. APIs tend to change or become deprecated, and without
+firmware updates there isn't much one can do. Which is exactly what happened here; the SMS gateway implementation broke
+and thanks to this thing not provide any logs or sources, who knows why. This leaves us with a few different channels to
+grab events from: Contact-ID - which I have no idea what that is and what to do with it - and E-Mail.
 
-I decided to abuse the E-Mail functionality to receive alarm (and status change) events by faking an SMTP-Server, which in turn transforms the mail body and sends it to an SMS gateway in proxy. The application uses .NET 8.0 and is designed as a Worker compatible with Docker, so it should run on any supported Linux system.
+I decided to abuse the E-Mail functionality to receive alarm (and status change) events by faking an SMTP-Server, which
+in turn transforms the mail body and sends it to an SMS gateway in proxy. The application uses .NET 8.0 and is designed
+as a Worker compatible with Docker, so it should run on any supported Linux system.
 
 ## Supported Systems
 
-The solution has been developed for and tested with the Lupusec XT1 (**not** Plus!) central station running Firmware version **1.0.89** and LupuServ hosted on a Raspberry Pi 2 Model B Rev 1.1 (ARM32). Currently two SMS gateway providers are implemented: [CM.com](https://www.cm.com/about-cm/) and [ClickSend](https://www.clicksend.com/eu/) so you need a registered account and top up a minimum balance for either of those.
+The solution has been developed for and tested with the Lupusec XT1 (**not** Plus!) central station running Firmware
+version **1.0.89** and LupuServ hosted on a Raspberry Pi 2 Model B Rev 1.1 (ARM32). Currently two SMS gateway providers
+are implemented: [CM.com](https://www.cm.com/about-cm/) and [ClickSend](https://www.clicksend.com/eu/) so you need a
+registered account and top up a minimum balance for either of those.
 
 ## Features
 
 - Can send messages to more than two recipients (limit of original firmware)
 - Stores status changes and alarm events in any MongoDB-compatible database
-  - The example compose file uses [FerretDB](https://github.com/FerretDB/FerretDB) with the [SQLite](https://www.sqlite.org/index.html) backend
-  - This way you can automatically keep a log e.g. off-site on what's going on in the monitored premises
+    - The example compose file uses [FerretDB](https://github.com/FerretDB/FerretDB) with
+      the [SQLite](https://www.sqlite.org/index.html) backend
+    - This way you can automatically keep a log e.g. off-site on what's going on in the monitored premises
 
 ## Limitations
 
-Some shortcuts have been taken on purpose while developing this proxy application. As of now I have no plans to rectify them or focus on additional features.
+Some shortcuts have been taken on purpose while developing this proxy application. As of now I have no plans to rectify
+them or focus on additional features.
 
 - SMTP-Server doesn't use authentication, it accepts any username and password
-  - This solution is meant to be operated in a firewall-protected private network, and without forced TLS protection plaintext authentication is a useless "security" measure anyway. It can be added quite easily though, consult the documentation of the SMTP library.
+    - This solution is meant to be operated in a firewall-protected private network, and without forced TLS protection
+      plaintext authentication is a useless "security" measure anyway. It can be added quite easily though, consult the
+      documentation of the SMTP library.
 - SMS gateway failures are logged, but no other notification happens
-  - SMS delivery errors can occur, like if the credit of the used account is depleted, this should be delivered to technical personnel via some way.
+    - SMS delivery errors can occur, like if the credit of the used account is depleted, this should be delivered to
+      technical personnel via some way.
 - Basic rate limits to mitigate SMS-bombing
-  - There's a rate limit in place for alarm mails to protect against unintended message spam. A shortcoming of the current implementation is that once the rate limit is hit, the message is dropped and not re-sent.
+    - There's a rate limit in place for alarm mails to protect against unintended message spam. A shortcoming of the
+      current implementation is that once the rate limit is hit, the message is dropped and not re-sent.
+- Only **German language** is supported and tested
+    - As mentioned earlier, I only have access to a German system. From my understanding, the language is hard-coded in
+      whatever firmware is applied and can't be changed, and I am not aware of the availability of other languages. As a
+      result, the message parsers created via reverse engineering currently only work with the German firmware variant.
 
 ## How to build
 
-Here's an example using my own tag (adapt accordingly). Since I plan on running the service on a Raspberry Pi 2 Model B Rev 1.1 (ARM32) and build on Windows amd64 we need to specify the correct target platform:
+Here's an example using my own tag (adapt accordingly). Since I plan on running the service on a Raspberry Pi 2 Model B
+Rev 1.1 (ARM32) and build on Windows amd64 we need to specify the correct target platform:
 
 ```bash
 docker build --platform linux/arm/v7 -t nefarius.azurecr.io/lupuserv:latest .
 docker push nefarius.azurecr.io/lupuserv:latest
 ```
 
-Since the Raspberry Pi has limited computing power, I prefer to build the image on my main PC and just download and run it on the Pi.
+Since the Raspberry Pi has limited computing power, I prefer to build the image on my main PC and just download and run
+it on the Pi.
 
 ## How to set up
 
@@ -56,9 +81,10 @@ You can choose one of the supported SMS Gateway Providers outlined below:
 <summary>Using CM.com</summary>
 
 - Register an account with [CM.com](https://www.cm.com/)
-  - Don't forget to respond to verification SMS and mail
-  - Add a balance of at least 15€ (as of time of writing) to unlock the Messaging gateway channel (which allows sending messages)
-  - Get the Product token/API key for the Messaging gateway
+    - Don't forget to respond to verification SMS and mail
+    - Add a balance of at least 15€ (as of time of writing) to unlock the Messaging gateway channel (which allows
+      sending messages)
+    - Get the Product token/API key for the Messaging gateway
 
 </details>
 
@@ -67,19 +93,22 @@ You can choose one of the supported SMS Gateway Providers outlined below:
 <summary>Using ClickSend</summary>
 
 - Register an account with [ClickSend](https://www.clicksend.com/eu/)
-  - Get the API Credentials (Username and Token) by clicking the key icon on the top right of your Dashboard
+    - Get the API Credentials (Username and Token) by clicking the key icon on the top right of your Dashboard
 
 </details>
 
 - Build and deploy this solution to a system of your choice
-  - For example, install Docker CE on a Raspberry Pi 2 and use the provided compose file to permanently run it as a container. There's plenty documentation out there on how to do that so I will not go into details here.
-    1) Rename `docker-compose.example.yml` to `docker-compose.yml` and adjust its content accordingly
-    2) Rename `appsettings.example.json` to `appsettings.json` and adjust content according to your environment
-    3) Run: `docker-compose up -d`
-- Configure the E-Mail settings on the XT1 web interface as shown below (I only had access to a German UI so it might look different on your system):
+    - For example, install Docker CE on a Raspberry Pi 2 and use the provided compose file to permanently run it as a
+      container. There's plenty documentation out there on how to do that so I will not go into details here.
+        1) Rename `docker-compose.example.yml` to `docker-compose.yml` and adjust its content accordingly
+        2) Rename `appsettings.example.json` to `appsettings.json` and adjust content according to your environment
+        3) Run: `docker-compose up -d`
+- Configure the E-Mail settings on the XT1 web interface as shown below (I only had access to a German UI so it might
+  look different on your system):
   ![Settings](./assets/ygJiBqVo8R.png)
 - You can use the Test E-Mail function and should be able to see it appear in the logs
-- **Optional:** to get Arm/Home/Disarm events sent as status messages you need to explicitly enable them in the PIN Codes settings:  
+- **Optional:** to get Arm/Home/Disarm events sent as status messages you need to explicitly enable them in the PIN
+  Codes settings:  
   ![PIN-Codes](./assets/D4JOzRXITd.png)
 
 ## Sources & 3rd party credits

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -9,7 +9,9 @@ services:
     restart: unless-stopped
     environment:
       - TZ=Europe/Vienna
-      - Service__ApiKey=<your API key here>
+      - Service__Gateway=ClickSend
+      - Service__ClickSend__Username=<YourClickSendUsername>
+      - Service__ClickSend__Token=<YourClickSendToken>
     volumes:
       - ./appsettings.json:/app/appsettings.json:ro
     ports:

--- a/src/LupuServ.csproj
+++ b/src/LupuServ.csproj
@@ -1,43 +1,51 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <DockerfileContext>.</DockerfileContext>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <ServerGarbageCollection>true</ServerGarbageCollection>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+        <DockerfileContext>.</DockerfileContext>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <ServerGarbageCollection>true</ServerGarbageCollection>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Ardalis.SmartEnum" Version="8.0.0" />
-    <PackageReference Include="CM.Text" Version="2.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
-    <PackageReference Include="MimeKit" Version="4.3.0" />
-    <PackageReference Include="MongoDB.Entities" Version="23.0.1" />
-    <PackageReference Include="Polly" Version="8.3.0" />
-    <PackageReference Include="Refit" Version="7.0.0" />
-    <PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />
-    <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
-    <PackageReference Include="SmtpServer" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Tiny.RestClient" Version="1.7.1" />
-  </ItemGroup>
+    <PropertyGroup>
+        <MinVerTagPrefix>v</MinVerTagPrefix>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <None Update="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Remove="Properties\launchSettings.json" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Ardalis.SmartEnum" Version="8.0.0"/>
+        <PackageReference Include="CM.Text" Version="2.7.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6"/>
+        <PackageReference Include="MimeKit" Version="4.3.0"/>
+        <PackageReference Include="MinVer" Version="4.3.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="MongoDB.Entities" Version="23.0.1"/>
+        <PackageReference Include="Polly" Version="8.3.0"/>
+        <PackageReference Include="Refit" Version="7.0.0"/>
+        <PackageReference Include="Refit.HttpClientFactory" Version="7.0.0"/>
+        <PackageReference Include="Serilog" Version="3.1.1"/>
+        <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0"/>
+        <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0"/>
+        <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1"/>
+        <PackageReference Include="SmtpServer" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
+        <PackageReference Include="Tiny.RestClient" Version="1.7.1"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Util\" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Update="appsettings.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Remove="Properties\launchSettings.json"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Folder Include="Util\"/>
+    </ItemGroup>
 
 </Project>

--- a/src/LupusMessageStore.cs
+++ b/src/LupusMessageStore.cs
@@ -114,19 +114,19 @@ public class LupusMessageStore : MessageStore
                 zoneMobilityEvent is not null)
             {
                 await zoneMobilityEvent.SaveAsync(cancellation: cancellationToken);
-                _logger.LogInformation("Zone status event inserted into DB");
+                _logger.LogDebug("Zone status event inserted into DB");
             }
             else if (PerimeterStatusEvent.TryParse(message.TextBody, out PerimeterStatusEvent? perimeterEvent) &&
                      perimeterEvent is not null)
             {
                 await perimeterEvent.SaveAsync(cancellation: cancellationToken);
-                _logger.LogInformation("Perimeter status event inserted into DB");
+                _logger.LogDebug("Perimeter status event inserted into DB");
             }
             else if (SensorStatusEvent.TryParse(message.TextBody, out SensorStatusEvent? statusEvent) &&
                      statusEvent is not null)
             {
                 await statusEvent.SaveAsync(cancellation: cancellationToken);
-                _logger.LogInformation("Sensor status event inserted into DB");
+                _logger.LogDebug("Sensor status event inserted into DB");
 
                 // send critical events to alarm subscribers
                 if (statusEvent.EventType.IsCritical)

--- a/src/LupusMessageStore.cs
+++ b/src/LupusMessageStore.cs
@@ -74,7 +74,7 @@ public class LupusMessageStore : MessageStore
             {
                 _logger.LogError(ex, "Failed to parse alarm event");
             }
-            
+
             string from = _config.From;
             List<string> recipients = _config.Recipients;
 
@@ -114,14 +114,53 @@ public class LupusMessageStore : MessageStore
                 zoneMobilityEvent is not null)
             {
                 await zoneMobilityEvent.SaveAsync(cancellation: cancellationToken);
-                _logger.LogDebug("Zone status event inserted into DB");
+                _logger.LogInformation("Zone status event inserted into DB");
             }
-
-            if (PerimeterStatusEvent.TryParse(message.TextBody, out PerimeterStatusEvent? perimeterEvent) &&
-                perimeterEvent is not null)
+            else if (PerimeterStatusEvent.TryParse(message.TextBody, out PerimeterStatusEvent? perimeterEvent) &&
+                     perimeterEvent is not null)
             {
                 await perimeterEvent.SaveAsync(cancellation: cancellationToken);
-                _logger.LogDebug("Perimeter status event inserted into DB");
+                _logger.LogInformation("Perimeter status event inserted into DB");
+            }
+            else if (SensorStatusEvent.TryParse(message.TextBody, out SensorStatusEvent? statusEvent) &&
+                     statusEvent is not null)
+            {
+                await statusEvent.SaveAsync(cancellation: cancellationToken);
+                _logger.LogInformation("Sensor status event inserted into DB");
+
+                // send critical events to alarm subscribers
+                if (statusEvent.EventType.IsCritical)
+                {
+                    string from = _config.From;
+                    List<string> recipients = _config.Recipients;
+
+                    try
+                    {
+                        SmtpResponse? response = await _rateLimit.ExecuteAsync(async () =>
+                        {
+                            _logger.LogInformation("Will send status SMS to the following recipients: {Recipients}",
+                                string.Join(", ", recipients));
+
+                            bool result =
+                                await _messageGateway.SendMessage(message.TextBody, from, recipients,
+                                    cancellationToken);
+
+                            return result ? SmtpResponse.Ok : SmtpResponse.TransactionFailed;
+                        });
+
+                        _logger.LogDebug("Text client send result: {@Result}", response);
+
+                        return response;
+                    }
+                    catch (RateLimitRejectedException ex)
+                    {
+                        _logger.LogError(ex, "Rate limit hit, message not sent");
+
+                        // TODO: implement retry strategy?
+
+                        return SmtpResponse.TransactionFailed;
+                    }
+                }
             }
         }
         else

--- a/src/Models/PerimeterStatusEventType.cs
+++ b/src/Models/PerimeterStatusEventType.cs
@@ -4,6 +4,9 @@ using Ardalis.SmartEnum;
 
 namespace LupuServ.Models;
 
+/// <summary>
+///     A type of <see cref="PerimeterStatusEvent"/>.
+/// </summary>
 [SuppressMessage("ReSharper", "UnusedMember.Global")]
 public sealed class PerimeterStatusEventType : SmartEnum<PerimeterStatusEventType>
 {

--- a/src/Models/SensorStatusEvent.cs
+++ b/src/Models/SensorStatusEvent.cs
@@ -1,0 +1,63 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+
+using MongoDB.Entities;
+
+namespace LupuServ.Models;
+
+/// <summary>
+///     Represents a special sensor status event.
+/// </summary>
+[SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
+public sealed partial class SensorStatusEvent : Entity
+{
+    /// <summary>
+    ///     Creation timestamp.
+    /// </summary>
+    public DateTime CreatedAt { get; private set; }
+
+    /// <summary>
+    ///     Gets the Zone ID (Sensor number).
+    /// </summary>
+    public int ZoneId { get; private set; }
+
+    /// <summary>
+    ///     Gets the sensor name.
+    /// </summary>
+    public string SensorName { get; private set; } = null!;
+
+    /// <summary>
+    ///     Gets the type of this event.
+    /// </summary>
+    public SensorStatusEventType EventType { get; private set; } = null!;
+
+    [GeneratedRegex(@"^Zone:(\d*) ([a-zA-Z\u00F0-\u02AF0-9 _.-]*), ([a-zA-Z\u00F0-\u02AF0-9 _.-]*)$")]
+    private static partial Regex SensorStatusRegex();
+
+    public static bool TryParse(string message, out SensorStatusEvent? parsedEvent)
+    {
+        Match match = SensorStatusRegex().Match(message);
+
+        if (!match.Success)
+        {
+            parsedEvent = null;
+            return false;
+        }
+
+        int zoneId = int.Parse(match.Groups[1].Value);
+        string sensorName = match.Groups[2].Value;
+
+        if (!SensorStatusEventType.TryFromName(match.Groups[3].Value, out SensorStatusEventType? eventType))
+        {
+            parsedEvent = null;
+            return false;
+        }
+
+        parsedEvent = new SensorStatusEvent
+        {
+            CreatedAt = DateTime.Now, ZoneId = zoneId, SensorName = sensorName, EventType = eventType
+        };
+
+        return true;
+    }
+}

--- a/src/Models/SensorStatusEventType.cs
+++ b/src/Models/SensorStatusEventType.cs
@@ -1,0 +1,27 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+using Ardalis.SmartEnum;
+
+namespace LupuServ.Models;
+
+/// <summary>
+///     A type of <see cref="SensorStatusEvent" />.
+/// </summary>
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+public sealed class SensorStatusEventType : SmartEnum<SensorStatusEventType>
+{
+    public static readonly SensorStatusEventType PeriodicTestReport =
+        new("Periodischer Test Report", 1) { IsCritical = false };
+
+    public static readonly SensorStatusEventType SensorMonitoringError =
+        new("Sensorüberwachungsfehler", 2) { IsCritical = true };
+
+    private SensorStatusEventType(string name, int value) : base(name, value)
+    {
+    }
+
+    /// <summary>
+    ///     Gets whether the event should be considered critical (inform the user in some way about it).
+    /// </summary>
+    public bool IsCritical { get; init; }
+}

--- a/src/Models/ZoneMobilityEventType.cs
+++ b/src/Models/ZoneMobilityEventType.cs
@@ -4,6 +4,9 @@ using Ardalis.SmartEnum;
 
 namespace LupuServ.Models;
 
+/// <summary>
+///     A type of <see cref="ZoneMobilityEvent"/>.
+/// </summary>
 [SuppressMessage("ReSharper", "UnusedMember.Global")]
 public sealed class ZoneMobilityEventType : SmartEnum<ZoneMobilityEventType>
 {


### PR DESCRIPTION
Noticed these new messages in the status body:

- `Zone:0 XXX, Periodischer Test Report`
- `Zone:5 XXX, Sensorüberwachungsfehler`

These can now be parsed properly by the new `SensorStatusEvent` type. Status messages of type `Sensorüberwachungsfehler` will also trigger sending a message to the alarm subscribers since this indicates a sensor having a flat battery or other connectivity issue.